### PR TITLE
fix: use environmentAlias instead of environment

### DIFF
--- a/src/locations/configScreen/ConfigScreen.tsx
+++ b/src/locations/configScreen/ConfigScreen.tsx
@@ -69,14 +69,14 @@ const ConfigScreen = () => {
     (async () => {
       const cts = await sdk.cma.contentType.getMany({
         spaceId: sdk.ids.space,
-        environmentId: sdk.ids.environment
+        environmentId: sdk.ids.environmentAlias
       })
 
       setAvailableContentTypes(cts.items.map(({ sys, name }) => ({ id: sys.id, name })))
 
       const editorInterfaces = await sdk.cma.editorInterface.getMany({
         spaceId: sdk.ids.space,
-        environmentId: sdk.ids.environment
+        environmentId: sdk.ids.environmentAlias
       })
 
       const assignedCts = editorInterfaces.items.reduce((acc, ei) => {

--- a/src/locations/dialogue/Dialogue.tsx
+++ b/src/locations/dialogue/Dialogue.tsx
@@ -173,7 +173,7 @@ function Dialogue () {
         action: scheduleAction,
         date: (scheduledDay as Date),
         entryId: sdk.parameters.invocation.entryId,
-        environmentId: sdk.ids.environment,
+        environmentId: sdk.ids.environmentAlias,
         time: scheduledTime,
         timezone
       })

--- a/src/locations/sidebar/Sidebar.tsx
+++ b/src/locations/sidebar/Sidebar.tsx
@@ -127,11 +127,11 @@ const Sidebar = () => {
 
   const getScheduledActions = useCallback(async () => {
     const payload = await sdk.cma.scheduledActions.getMany({
-      environmentId: sdk.ids.environment,
+      environmentId: sdk.ids.environmentAlias,
       spaceId: sdk.ids.space,
       query: {
         'entity.sys.id': sdk.ids.entry,
-        'environment.sys.id': sdk.ids.environment
+        'environment.sys.id': sdk.ids.environmentAlias
       }
     })
     setScheduledActions(payload.items.filter(({ sys }) => sys.status === 'scheduled'))
@@ -145,7 +145,7 @@ const Sidebar = () => {
         const { sys: { id } } = await sdk.cma.bulkAction.validate(
           {
             spaceId: sdk.ids.space,
-            environmentId: sdk.ids.environment
+            environmentId: sdk.ids.environmentAlias
           },
           {
             entities: {
@@ -168,7 +168,7 @@ const Sidebar = () => {
   useEffect(() => {
     const checkValidationResults = async () => {
       const { controls = [] } = await sdk.cma.editorInterface.get({
-        environmentId: sdk.ids.environment,
+        environmentId: sdk.ids.environmentAlias,
         spaceId: sdk.ids.space,
         contentTypeId: sdk.ids.contentType
       })
@@ -190,7 +190,7 @@ const Sidebar = () => {
       if (entityValidationId) {
         const validationResults = await sdk.cma.bulkAction.get({
           spaceId: sdk.ids.space,
-          environmentId: sdk.ids.environment,
+          environmentId: sdk.ids.environmentAlias,
           bulkActionId: entityValidationId
         })
         if (validationResults.error) {

--- a/src/locations/sidebar/components/PublishButton.tsx
+++ b/src/locations/sidebar/components/PublishButton.tsx
@@ -88,7 +88,7 @@ function PublishButton ({
 
   const createEntryUrl = (entryId: string) => (
     new URL(
-      `/spaces/${sdk.ids.space}/environments/${sdk.ids.environment}/entries/${entryId}`,
+      `/spaces/${sdk.ids.space}/environments/${sdk.ids.environmentAlias}/entries/${entryId}`,
       'https://app.contentful.com'
     ).toString()
   )
@@ -101,7 +101,7 @@ function PublishButton ({
       } else {
         const linksToEntry = await sdk.cma.entry.getMany({
           spaceId: sdk.ids.space,
-          environmentId: sdk.ids.environment,
+          environmentId: sdk.ids.environmentAlias,
           query: { links_to_entry: sdk.ids.entry }
         })
 
@@ -126,7 +126,7 @@ function PublishButton ({
     try {
       const linksToEntry = await sdk.cma.entry.getMany({
         spaceId: sdk.ids.space,
-        environmentId: sdk.ids.environment,
+        environmentId: sdk.ids.environmentAlias,
         query: { links_to_entry: sdk.ids.entry }
       })
 

--- a/src/locations/sidebar/components/ScheduleSection.tsx
+++ b/src/locations/sidebar/components/ScheduleSection.tsx
@@ -44,7 +44,7 @@ const ScheduleSection = ({
       if (isConfirmed) {
         await sdk.cma.scheduledActions.delete({
           spaceId: sdk.ids.space,
-          environmentId: sdk.ids.environment,
+          environmentId: sdk.ids.environmentAlias,
           scheduledActionId: action.sys.id
         })
         sdk.notifier.warning('Scheduled action canceled')


### PR DESCRIPTION
This PR aims to resolve the editor publishing issues by changing instances of `sdk.ids.environment` to `sdk.ids.environmentAlias`. 