### PR TITLE
fix: fall back on contentful environment id when alias is undefined

### DIFF
--- a/src/locations/configScreen/ConfigScreen.tsx
+++ b/src/locations/configScreen/ConfigScreen.tsx
@@ -69,14 +69,14 @@ const ConfigScreen = () => {
     (async () => {
       const cts = await sdk.cma.contentType.getMany({
         spaceId: sdk.ids.space,
-        environmentId: sdk.ids.environmentAlias
+        environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment
       })
 
       setAvailableContentTypes(cts.items.map(({ sys, name }) => ({ id: sys.id, name })))
 
       const editorInterfaces = await sdk.cma.editorInterface.getMany({
         spaceId: sdk.ids.space,
-        environmentId: sdk.ids.environmentAlias
+        environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment
       })
 
       const assignedCts = editorInterfaces.items.reduce((acc, ei) => {

--- a/src/locations/dialogue/Dialogue.tsx
+++ b/src/locations/dialogue/Dialogue.tsx
@@ -173,7 +173,7 @@ function Dialogue () {
         action: scheduleAction,
         date: (scheduledDay as Date),
         entryId: sdk.parameters.invocation.entryId,
-        environmentId: sdk.ids.environmentAlias,
+        environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
         time: scheduledTime,
         timezone
       })

--- a/src/locations/sidebar/Sidebar.tsx
+++ b/src/locations/sidebar/Sidebar.tsx
@@ -127,11 +127,11 @@ const Sidebar = () => {
 
   const getScheduledActions = useCallback(async () => {
     const payload = await sdk.cma.scheduledActions.getMany({
-      environmentId: sdk.ids.environmentAlias,
+      environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
       spaceId: sdk.ids.space,
       query: {
         'entity.sys.id': sdk.ids.entry,
-        'environment.sys.id': sdk.ids.environmentAlias
+        'environment.sys.id': sdk.ids.environmentAlias ?? sdk.ids.environment
       }
     })
     setScheduledActions(payload.items.filter(({ sys }) => sys.status === 'scheduled'))
@@ -145,7 +145,7 @@ const Sidebar = () => {
         const { sys: { id } } = await sdk.cma.bulkAction.validate(
           {
             spaceId: sdk.ids.space,
-            environmentId: sdk.ids.environmentAlias
+            environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment
           },
           {
             entities: {
@@ -168,7 +168,7 @@ const Sidebar = () => {
   useEffect(() => {
     const checkValidationResults = async () => {
       const { controls = [] } = await sdk.cma.editorInterface.get({
-        environmentId: sdk.ids.environmentAlias,
+        environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
         spaceId: sdk.ids.space,
         contentTypeId: sdk.ids.contentType
       })
@@ -190,7 +190,7 @@ const Sidebar = () => {
       if (entityValidationId) {
         const validationResults = await sdk.cma.bulkAction.get({
           spaceId: sdk.ids.space,
-          environmentId: sdk.ids.environmentAlias,
+          environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
           bulkActionId: entityValidationId
         })
         if (validationResults.error) {

--- a/src/locations/sidebar/components/PublishButton.tsx
+++ b/src/locations/sidebar/components/PublishButton.tsx
@@ -86,9 +86,11 @@ function PublishButton ({
     }
   }
 
+  const contentfulEnv = sdk.ids.environmentAlias ?? sdk.ids.environment
+
   const createEntryUrl = (entryId: string) => (
     new URL(
-      `/spaces/${sdk.ids.space}/environments/${sdk.ids.environmentAlias}/entries/${entryId}`,
+      `/spaces/${sdk.ids.space}/environments/${contentfulEnv}/entries/${entryId}`,
       'https://app.contentful.com'
     ).toString()
   )
@@ -101,7 +103,7 @@ function PublishButton ({
       } else {
         const linksToEntry = await sdk.cma.entry.getMany({
           spaceId: sdk.ids.space,
-          environmentId: sdk.ids.environmentAlias,
+          environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
           query: { links_to_entry: sdk.ids.entry }
         })
 
@@ -126,7 +128,7 @@ function PublishButton ({
     try {
       const linksToEntry = await sdk.cma.entry.getMany({
         spaceId: sdk.ids.space,
-        environmentId: sdk.ids.environmentAlias,
+        environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
         query: { links_to_entry: sdk.ids.entry }
       })
 

--- a/src/locations/sidebar/components/ScheduleSection.tsx
+++ b/src/locations/sidebar/components/ScheduleSection.tsx
@@ -44,7 +44,7 @@ const ScheduleSection = ({
       if (isConfirmed) {
         await sdk.cma.scheduledActions.delete({
           spaceId: sdk.ids.space,
-          environmentId: sdk.ids.environmentAlias,
+          environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
           scheduledActionId: action.sys.id
         })
         sdk.notifier.warning('Scheduled action canceled')


### PR DESCRIPTION
i've replaced instances of `sdk.ids.environmentAlias` with `sdk.ids.environmentAlias ?? sdk.ids.environment` to handle cases where there is no environment alias. 